### PR TITLE
Update driven by deprication warning

### DIFF
--- a/src/routes/message.js
+++ b/src/routes/message.js
@@ -1,4 +1,4 @@
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import { Router } from 'express';
 
 const router = Router();


### PR DESCRIPTION
(node:50300) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid#deep-requires-now-deprecated for more information.