### PR TITLE
feat(put): add put endpoint and implementation to the message route

### DIFF
--- a/src/routes/message.js
+++ b/src/routes/message.js
@@ -35,4 +35,19 @@ router.delete('/:messageId', (req, res) => {
   return res.send(message);
 });
 
+router.put('/:messageId', (req, res) => {
+  const {
+    [req.params.messageId]: message
+  } = req.context.models.messages;
+
+  const updatedMessage = {
+    ...message,
+    text: req.body.text
+  };
+
+  req.context.models.messages[req.params.messageId] = updatedMessage;
+
+  return res.send(updatedMessage);
+})
+
 export default router;


### PR DESCRIPTION
## Description
This PR introduces a new `PUT` method for updating existing records in the **Messages** array, enhancing the RESTful capabilities of the API. This update allows users to modify the contents of messages.

## Changes
- Added a `PUT` route in `src/routes/message.js`.
- Implemented the corresponding handler for updating messages in memory.

## Specifics of the New Feature
The new `PUT` method enables users to update an existing message by sending a request to `http://localhost:3000/messages/:messageId`. The method expects data in `x-www-form-urlencoded` format with the updated `text` field of the message. It responds with the updated message data, including `text`, `id`, and `userID`.

### How to Test the Feature
To test the new feature using Postman:
1. Open Postman and set up a new PUT request to `http://localhost:3000/messages/1`.
2. In the Body of the request, choose `x-www-form-urlencoded`.
3. Add the key `text` and enter the updated message text as the value, for example:
